### PR TITLE
Detect if FDBLock is stolen by another writer

### DIFF
--- a/src/main/java/com/cloudant/fdblucene/FDBDirectory.java
+++ b/src/main/java/com/cloudant/fdblucene/FDBDirectory.java
@@ -321,7 +321,7 @@ public final class FDBDirectory extends Directory {
 
     @Override
     public Lock obtainLock(final String name) throws IOException {
-        return FDBLock.obtain(this, name);
+        return FDBLock.obtain(this, uuid, name);
     }
 
     /**

--- a/src/main/java/com/cloudant/fdblucene/FDBDirectory.java
+++ b/src/main/java/com/cloudant/fdblucene/FDBDirectory.java
@@ -34,7 +34,6 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.Lock;
-import org.apache.lucene.store.LockObtainFailedException;
 
 import com.apple.foundationdb.Database;
 import com.apple.foundationdb.KeyValue;
@@ -322,12 +321,7 @@ public final class FDBDirectory extends Directory {
 
     @Override
     public Lock obtainLock(final String name) throws IOException {
-        try {
-            createOutput(name, null).close();
-            return new FDBLock(this, name);
-        } catch (FileAlreadyExistsException e) {
-            throw new LockObtainFailedException("Lock for " + name + " already obtained.", e);
-        }
+        return FDBLock.obtain(this, name);
     }
 
     /**

--- a/src/main/java/com/cloudant/fdblucene/FDBLock.java
+++ b/src/main/java/com/cloudant/fdblucene/FDBLock.java
@@ -18,29 +18,38 @@ package com.cloudant.fdblucene;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
+import java.util.UUID;
 
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.Lock;
 import org.apache.lucene.store.LockObtainFailedException;
 
 final class FDBLock extends Lock {
 
     private final Directory dir;
+    private final UUID uuid;
     private final String name;
+    private boolean invalid = false;
     private boolean closed = false;
 
-    public static Lock obtain(final Directory dir, final String name) throws IOException {
+    public static Lock obtain(final Directory dir, final UUID uuid, final String name) throws IOException {
         try {
-            dir.createOutput(name, null).close();
-            return new FDBLock(dir, name);
+            try (final IndexOutput output = dir.createOutput(name, null)) {
+                output.writeLong(uuid.getMostSignificantBits());
+                output.writeLong(uuid.getLeastSignificantBits());
+            }
+            return new FDBLock(dir, uuid, name);
         } catch (FileAlreadyExistsException e) {
             throw new LockObtainFailedException("Lock for " + name + " already obtained.", e);
         }
     }
 
-    FDBLock(final Directory dir, final String name) {
+    FDBLock(final Directory dir, final UUID uuid, final String name) {
         this.dir = dir;
+        this.uuid = uuid;
         this.name = name;
     }
 
@@ -58,11 +67,21 @@ final class FDBLock extends Lock {
         if (closed) {
             throw new AlreadyClosedException(name + " already closed.");
         }
-
-        try {
-            dir.fileLength(name);
-        } catch (final FileNotFoundException e) {
+        if (invalid) {
             throw new IOException(name + " no longer valid");
+        }
+
+        try (final IndexInput input = dir.openInput(name, null)) {
+            final long msb = input.readLong();
+            final long lsb = input.readLong();
+            final UUID current = new UUID(msb, lsb);
+            if (!this.uuid.equals(current)) {
+                invalid = true;
+                ensureValid();
+            }
+        } catch (final FileNotFoundException e) {
+            invalid = true;
+            ensureValid();
         }
     }
 

--- a/src/main/java/com/cloudant/fdblucene/FDBLock.java
+++ b/src/main/java/com/cloudant/fdblucene/FDBLock.java
@@ -17,16 +17,27 @@ package com.cloudant.fdblucene;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.Lock;
+import org.apache.lucene.store.LockObtainFailedException;
 
 final class FDBLock extends Lock {
 
     private final Directory dir;
     private final String name;
     private boolean closed = false;
+
+    public static Lock obtain(final Directory dir, final String name) throws IOException {
+        try {
+            dir.createOutput(name, null).close();
+            return new FDBLock(dir, name);
+        } catch (FileAlreadyExistsException e) {
+            throw new LockObtainFailedException("Lock for " + name + " already obtained.", e);
+        }
+    }
 
     FDBLock(final Directory dir, final String name) {
         this.dir = dir;


### PR DESCRIPTION
Ensure that a crashed JVM won't leave directories locked forever.