### PR TITLE
Fix close after delete

### DIFF
--- a/src/main/java/com/cloudant/fdblucene/FDBDirectory.java
+++ b/src/main/java/com/cloudant/fdblucene/FDBDirectory.java
@@ -51,7 +51,7 @@ import com.apple.foundationdb.tuple.Tuple;
  */
 public final class FDBDirectory extends Directory {
 
-    private static class FileMetaData {
+    static class FileMetaData {
 
         private final Tuple asTuple;
 
@@ -241,7 +241,8 @@ public final class FDBDirectory extends Directory {
         }
 
         final String resourceDescription = String.format("FDBIndexOutput(name=%s,number=%d)", name, fileNumber);
-        return new FDBIndexOutput(this, resourceDescription, name, txc, fileSubspace(fileNumber), pageSize, txnSize);
+        return new FDBIndexOutput(this, resourceDescription, name, txc, metaKey(name), fileSubspace(fileNumber),
+                pageSize, txnSize);
     }
 
     /**
@@ -294,16 +295,6 @@ public final class FDBDirectory extends Directory {
         }
 
         return meta.getFileLength();
-    }
-
-    void setFileLength(final TransactionContext txc, final String name, final long length) {
-        final byte[] metaKey = metaKey(name);
-        txc.run(txn -> {
-            final byte[] value = txn.get(metaKey).join();
-            final FileMetaData meta = new FileMetaData(value).setFileLength(length);
-            txn.set(metaKey, meta.pack());
-            return null;
-        });
     }
 
     @Override

--- a/src/test/java/com/cloudant/fdblucene/SimpleFDBDirectoryTest.java
+++ b/src/test/java/com/cloudant/fdblucene/SimpleFDBDirectoryTest.java
@@ -186,6 +186,19 @@ public class SimpleFDBDirectoryTest {
         }
     }
 
+    @Test
+    public void testCloseAfterDeleteShouldntThrow() throws Exception {
+        final Directory dir = FDBDirectory.open(DB, FileSystems.getDefault().getPath("lucene", "test1"));
+        assertCloseDoesntThrowOnDeletedFile(dir);
+    }
+
+    private void assertCloseDoesntThrowOnDeletedFile(final Directory dir) throws Exception {
+        cleanupDir(dir);
+        final IndexOutput out = dir.createOutput("foo", null);
+        dir.deleteFile("foo");
+        out.close();
+    }
+
     private void addDocument(final IndexWriter writer, final String docId) throws IOException {
         final Document doc = new Document();
         doc.add(new TextField("foo", "hello everybody", Store.NO));


### PR DESCRIPTION
FDBIndexOutput.close() and the internal flush can throw an exception if the file was deleted in a previous transaction.

We now check for the metadata key's existence before writing the buffered output.