### PR TITLE
Use the env-conditional `Utils.trace` method for setting transaction trace-logging/descriptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,6 @@
         <version>3.0.0-M3</version>
         <configuration>
           <environmentVariables>
-            <FDB_NETWORK_OPTION_TRACE_ENABLE></FDB_NETWORK_OPTION_TRACE_ENABLE>
           </environmentVariables>
           <argLine>-server -Xmx2G</argLine>
         </configuration>

--- a/src/main/java/com/cloudant/fdblucene/FDBDirectory.java
+++ b/src/main/java/com/cloudant/fdblucene/FDBDirectory.java
@@ -189,6 +189,7 @@ public final class FDBDirectory extends Directory {
         this.txc = txc;
         this.subspace = subspace;
         this.closed = false;
+        this.uuid = UUID.randomUUID();
         this.pageSize = getOrSetPageSize(txc, subspace, pageSize);
         this.txnSize = txnSize;
 
@@ -196,7 +197,6 @@ public final class FDBDirectory extends Directory {
             throw new IllegalArgumentException("txnSize cannot be smaller than pageSize");
         }
 
-        this.uuid = UUID.randomUUID();
         this.pageCache = JCS.getGroupCacheInstance(uuid.toString());
     }
 

--- a/src/main/java/com/cloudant/fdblucene/FDBDirectory.java
+++ b/src/main/java/com/cloudant/fdblucene/FDBDirectory.java
@@ -209,6 +209,7 @@ public final class FDBDirectory extends Directory {
      */
     public void delete() {
         txc.run(txn -> {
+            Utils.trace(txn, "FDBDirectory.delete");
             txn.clear(subspace.range());
             return null;
         });
@@ -423,6 +424,7 @@ public final class FDBDirectory extends Directory {
     private int getOrSetPageSize(final TransactionContext txc, final Subspace subspace, final int pageSize) {
         final byte[] key = subspace.pack(Tuple.from("_pagesize"));
         return txc.run(txn -> {
+            Utils.trace(txn, "getOrSetPageSize");
             final byte[] pageSizeInFDB = txn.get(key).join();
             if (pageSizeInFDB == null) {
                 txn.set(key, FDBUtil.encodeInt(pageSize));

--- a/src/main/java/com/cloudant/fdblucene/FDBDirectory.java
+++ b/src/main/java/com/cloudant/fdblucene/FDBDirectory.java
@@ -35,6 +35,8 @@ import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.Lock;
 
+import com.cloudant.fdblucene.Utils;
+
 import com.apple.foundationdb.Database;
 import com.apple.foundationdb.KeyValue;
 import com.apple.foundationdb.Range;
@@ -234,7 +236,7 @@ public final class FDBDirectory extends Directory {
         final byte[] key = metaKey(name);
 
         final long fileNumber = txc.run(txn -> {
-            txn.options().setTransactionLoggingEnable(String.format("createOutput(%s)", name));
+            Utils.trace(txn, "createOutput(%s)", name);
             final byte[] value = txn.get(key).join();
             if (value != null) {
                 return -1L;
@@ -278,7 +280,7 @@ public final class FDBDirectory extends Directory {
     @Override
     public void deleteFile(final String name) throws IOException {
         final boolean deleted = txc.run(txn -> {
-            txn.options().setTransactionLoggingEnable(String.format("deleteFile(%s)", name));
+            Utils.trace(txn, "deleteFile(%s)", name);
             final long fileNumber = fileNumber(txn, name);
             if (fileNumber != -1L) {
                 txn.clear(metaKey(name));
@@ -310,7 +312,7 @@ public final class FDBDirectory extends Directory {
     public String[] listAll() throws IOException {
         final Range metaRange = metaRange();
         final List<KeyValue> keyvalues = txc.read(txn -> {
-            txn.options().setTransactionLoggingEnable("listAll");
+            Utils.trace(txn, "listAll");
             return txn.getRange(metaRange).asList().join();
         });
 
@@ -361,7 +363,7 @@ public final class FDBDirectory extends Directory {
         final byte[] destKey = metaKey(dest);
 
         txc.run(txn -> {
-            txn.options().setTransactionLoggingEnable(String.format("rename(%s,%s)", source, dest));
+            Utils.trace(txn, "rename(%s,%s)", source, dest);
             final FileMetaData meta = meta(txn, source);
             txn.clear(sourceKey);
             txn.set(destKey, meta.pack());

--- a/src/main/java/com/cloudant/fdblucene/FDBDirectory.java
+++ b/src/main/java/com/cloudant/fdblucene/FDBDirectory.java
@@ -209,7 +209,7 @@ public final class FDBDirectory extends Directory {
      */
     public void delete() {
         txc.run(txn -> {
-            Utils.trace(txn, "FDBDirectory.delete");
+            Utils.trace(txn, "FDBDirectory.delete(%s)", uuid);
             txn.clear(subspace.range());
             return null;
         });
@@ -237,7 +237,7 @@ public final class FDBDirectory extends Directory {
         final byte[] key = metaKey(name);
 
         final long fileNumber = txc.run(txn -> {
-            Utils.trace(txn, "createOutput(%s)", name);
+            Utils.trace(txn, "FDBDirectory.createOutput(%s)", name);
             final byte[] value = txn.get(key).join();
             if (value != null) {
                 return -1L;
@@ -281,7 +281,7 @@ public final class FDBDirectory extends Directory {
     @Override
     public void deleteFile(final String name) throws IOException {
         final boolean deleted = txc.run(txn -> {
-            Utils.trace(txn, "deleteFile(%s)", name);
+            Utils.trace(txn, "FDBDirectory.deleteFile(%s)", name);
             final long fileNumber = fileNumber(txn, name);
             if (fileNumber != -1L) {
                 txn.clear(metaKey(name));
@@ -313,7 +313,7 @@ public final class FDBDirectory extends Directory {
     public String[] listAll() throws IOException {
         final Range metaRange = metaRange();
         final List<KeyValue> keyvalues = txc.read(txn -> {
-            Utils.trace(txn, "listAll");
+            Utils.trace(txn, "FDBDirectory.listAll(%s)", uuid);
             return txn.getRange(metaRange).asList().join();
         });
 
@@ -364,7 +364,7 @@ public final class FDBDirectory extends Directory {
         final byte[] destKey = metaKey(dest);
 
         txc.run(txn -> {
-            Utils.trace(txn, "rename(%s,%s)", source, dest);
+            Utils.trace(txn, "FDBDirectory.rename(%s,%s)", source, dest);
             final FileMetaData meta = meta(txn, source);
             txn.clear(sourceKey);
             txn.set(destKey, meta.pack());
@@ -424,7 +424,7 @@ public final class FDBDirectory extends Directory {
     private int getOrSetPageSize(final TransactionContext txc, final Subspace subspace, final int pageSize) {
         final byte[] key = subspace.pack(Tuple.from("_pagesize"));
         return txc.run(txn -> {
-            Utils.trace(txn, "getOrSetPageSize");
+            Utils.trace(txn, "FDBDirectory.getOrSetPageSize(%s)", uuid);
             final byte[] pageSizeInFDB = txn.get(key).join();
             if (pageSizeInFDB == null) {
                 txn.set(key, FDBUtil.encodeInt(pageSize));

--- a/src/main/java/com/cloudant/fdblucene/FDBIndexInput.java
+++ b/src/main/java/com/cloudant/fdblucene/FDBIndexInput.java
@@ -22,6 +22,8 @@ import org.apache.commons.jcs.JCS;
 import org.apache.commons.jcs.access.GroupCacheAccess;
 import org.apache.lucene.store.IndexInput;
 
+import com.cloudant.fdblucene.Utils;
+
 import com.apple.foundationdb.TransactionContext;
 import com.apple.foundationdb.subspace.Subspace;
 
@@ -135,7 +137,7 @@ public final class FDBIndexInput extends IndexInput {
                 final byte[] key = pageKey(currentPage);
                 page = txc.run(txn -> {
                     readVersionCache.setReadVersion(txn);
-                    txn.options().setTransactionLoggingEnable(String.format("%s,in,loadPage,%d", name, offset + pointer));
+                    Utils.trace(txn, "%s,in,loadPage,%d", name, offset + pointer);
                     return txn.get(key).join();
                 });
                 pageCache.putInGroup(currentPage, name, page);

--- a/src/main/java/com/cloudant/fdblucene/FDBIndexOutput.java
+++ b/src/main/java/com/cloudant/fdblucene/FDBIndexOutput.java
@@ -100,7 +100,7 @@ public final class FDBIndexOutput extends IndexOutput {
         lastFlushFuture.join();
         txc.run(txn -> {
             readVersionCache.setReadVersion(txn);
-            Utils.trace(txn, "%s,out,close,%d", getName(), pointer);
+            Utils.trace(txn, "FDBIndexOutput.close(%s,%d)", getName(), pointer);
             flushTxnBuffer(subspace, txn, txnBuffer, txnBufferOffset, pointer, pageSize);
             txn.options().setNextWriteNoWriteConflictRange();
 
@@ -155,7 +155,7 @@ public final class FDBIndexOutput extends IndexOutput {
 
         lastFlushFuture = txc.runAsync(txn -> {
             readVersionCache.setReadVersion(txn);
-            Utils.trace(txn, "%s,out,flush,%d", getName(), pointer);
+            Utils.trace(txn, "FDBIndexOutput.flushTxnBuffer(%s, %d)", getName(), pointer);
             applyIfExists(txn, value -> {
                 flushTxnBuffer(subspace, txn, txnBuffer, txnBufferOffset, pointer, pageSize);
             });

--- a/src/main/java/com/cloudant/fdblucene/FDBIndexOutput.java
+++ b/src/main/java/com/cloudant/fdblucene/FDBIndexOutput.java
@@ -22,6 +22,8 @@ import java.util.zip.CRC32;
 
 import org.apache.lucene.store.IndexOutput;
 
+import com.cloudant.fdblucene.Utils;
+
 import com.apple.foundationdb.Transaction;
 import com.apple.foundationdb.TransactionContext;
 import com.apple.foundationdb.async.AsyncUtil;
@@ -98,7 +100,7 @@ public final class FDBIndexOutput extends IndexOutput {
         lastFlushFuture.join();
         txc.run(txn -> {
             readVersionCache.setReadVersion(txn);
-            txn.options().setTransactionLoggingEnable(String.format("%s,out,close,%d", getName(), pointer));
+            Utils.trace(txn, "%s,out,close,%d", getName(), pointer);
             flushTxnBuffer(subspace, txn, txnBuffer, txnBufferOffset, pointer, pageSize);
             txn.options().setNextWriteNoWriteConflictRange();
 
@@ -153,7 +155,7 @@ public final class FDBIndexOutput extends IndexOutput {
 
         lastFlushFuture = txc.runAsync(txn -> {
             readVersionCache.setReadVersion(txn);
-            txn.options().setTransactionLoggingEnable(String.format("%s,out,flush,%d", getName(), pointer));
+            Utils.trace(txn, "%s,out,flush,%d", getName(), pointer);
             applyIfExists(txn, value -> {
                 flushTxnBuffer(subspace, txn, txnBuffer, txnBufferOffset, pointer, pageSize);
             });

--- a/src/main/java/com/cloudant/fdblucene/Utils.java
+++ b/src/main/java/com/cloudant/fdblucene/Utils.java
@@ -20,13 +20,13 @@ import java.util.UUID;
 
 import org.apache.lucene.util.BytesRef;
 
-import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.ReadTransaction;
 import com.apple.foundationdb.TransactionContext;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
 
 class Utils {
 
-    static void trace(final Transaction txn, final String format, final Object... args) {
+    static void trace(final ReadTransaction txn, final String format, final Object... args) {
         if (System.getenv("FDB_NETWORK_OPTION_TRACE_ENABLE") != null) {
             final String str = String.format(format, args);
             txn.options().setTransactionLoggingEnable(str);


### PR DESCRIPTION
In this PR I:
  - Make use of the env-conditional `Utils.trace` method due to transaction performance concerns when the logging description is set despite the env not being set
  - Trace all transactions with a description, if possible
  - Make the transaction log descriptions a little more clear and uniform throughout the codebase
  - Remove tracing env from pom.xml -- it was always turning on tracing

`FDBDirectory.getAndIncrement` and `FDBIndexOutput.setFileLength` are suspect -- these are blocking transactions run within the assembly of another blocking transaction. I found this out as trying to set the logging description within the innermost context fails. We should consider ditching the inner `TransactionContext.run` for these methods if it's not intentional.