### PR TITLE
Trace uuids when locking, improve txn descriptions in FDBIndexOutput

### DIFF
--- a/src/main/java/com/cloudant/fdblucene/FDBDirectory.java
+++ b/src/main/java/com/cloudant/fdblucene/FDBDirectory.java
@@ -373,7 +373,7 @@ public final class FDBDirectory extends Directory {
     }
 
     public void unlock(final String name) {
-        FDBLock.unlock(txc, subspace, name);
+        FDBLock.unlock(txc, subspace, uuid, name);
     }
 
     /**

--- a/src/main/java/com/cloudant/fdblucene/FDBIndexOutput.java
+++ b/src/main/java/com/cloudant/fdblucene/FDBIndexOutput.java
@@ -100,7 +100,7 @@ public final class FDBIndexOutput extends IndexOutput {
         lastFlushFuture.join();
         txc.run(txn -> {
             readVersionCache.setReadVersion(txn);
-            Utils.trace(txn, "FDBIndexOutput.close(%s,%d)", getName(), pointer);
+            Utils.trace(txn, "FDBIndexOutput.close(%s,%s,%d)", this.dir.getUUID(), getName(), pointer);
             flushTxnBuffer(subspace, txn, txnBuffer, txnBufferOffset, pointer, pageSize);
             txn.options().setNextWriteNoWriteConflictRange();
 
@@ -155,7 +155,7 @@ public final class FDBIndexOutput extends IndexOutput {
 
         lastFlushFuture = txc.runAsync(txn -> {
             readVersionCache.setReadVersion(txn);
-            Utils.trace(txn, "FDBIndexOutput.flushTxnBuffer(%s, %d)", getName(), pointer);
+            Utils.trace(txn, "FDBIndexOutput.flushTxnBuffer(%s,%s,%d)", this.dir.getUUID(), getName(), pointer);
             applyIfExists(txn, value -> {
                 flushTxnBuffer(subspace, txn, txnBuffer, txnBufferOffset, pointer, pageSize);
             });


### PR DESCRIPTION
In this PR I make sure lock-related and FDBIndexOutput transaction traces are uniquely identified with the lock name, FDBDirectory UUID, Lucene 'filename' etc.